### PR TITLE
Array indexing bugfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "a2ltool"
-version = "0.9.2"
+version = "1.0.1"
 dependencies = [
  "a2lfile",
  "clap",
@@ -41,9 +41,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
@@ -67,9 +67,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cfg-if"
@@ -79,9 +79,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
@@ -94,18 +94,18 @@ dependencies = [
 
 [[package]]
 name = "cpp_demangle"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea47428dc9d2237f3c6bc134472edfd63ebba0af932e783506dcfd66f10d18a"
+checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if",
 ]
@@ -118,9 +118,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "flate2"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -141,24 +141,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "8e167738f1866a7ec625567bae89ca0d44477232a4f7c52b1c7f2adc2c98804f"
 
 [[package]]
 name = "memchr"
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c821014c18301591b89b843809ef953af9e3df0496c232d5c0611b0a52aac363"
+checksum = "7ce8b38d41f9f3618fc23f908faae61510f8d8ce2d99cbe910641e8f1971f084"
 dependencies = [
  "flate2",
  "memchr",
@@ -208,18 +208,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "fb37d2df5df740e582f28f8560cf425f52bb267d872fe58358eadb554909f07a"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
@@ -247,15 +247,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "a2ltool"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Daniel Thaler <daniel@dthaler.de>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 a2lfile = "1.0.0"
-object = "~0.27"
-gimli = "~0.25"
+object = "~0.28"
+gimli = { version = "~0.26", features = ["read"] }
 memmap = "~0.7"
-clap = "~2.33.0"
-cpp_demangle = "0.3.3"
+clap = "~2.34"
+cpp_demangle = "0.3.5"

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -3,6 +3,9 @@ use super::ifdata;
 use a2lfile::*;
 use std::collections::HashSet;
 
+#[cfg(test)]
+use std::collections::HashMap;
+
 mod axis_pts;
 mod blob;
 mod characteristic;
@@ -203,7 +206,14 @@ fn get_symbol_name_from_ifdata(ifdata_vec: &Vec<IfData>) -> Option<String> {
 // find a symbol in the elf_info data structure that was derived from the DWARF debug info in the elf file
 fn find_symbol<'a>(varname: &str, debug_data: &'a DebugData) -> Option<(u64, &'a TypeInfo)> {
     // split the a2l symbol name: e.g. "motortune.param._0_" -> ["motortune", "param", "_0_"]
-    let components: Vec<&str> = varname.split('.').collect();
+    let components = split_symbol_components(varname);
+
+    // find the symbol in the symbol table
+    find_symbol_from_components(&components, debug_data)
+}
+
+
+fn find_symbol_from_components<'a>(components: &Vec<&str>, debug_data: &'a DebugData) -> Option<(u64, &'a TypeInfo)> {
     // the first component of the symbol name is the name of the global variable.
     if let Some(varinfo) = debug_data.variables.get(components[0]) {
         // we also need the type in order to resolve struct members, etc.
@@ -225,10 +235,30 @@ fn find_symbol<'a>(varname: &str, debug_data: &'a DebugData) -> Option<(u64, &'a
 }
 
 
+// split the symbol into components
+// e.g. "my_struct.array_field[5][6]" -> [ "my_struct", "array_field", "[5]", "[6]" ]
+fn split_symbol_components(varname: &str) -> Vec<&str> {
+    let mut components: Vec<&str> = Vec::new();
+
+    for component in varname.split('.') {
+        if let Some(idx) = component.find('[') {
+            // "array_field[5][6]" -> "array_field", "[5][6]"
+            let (name, indexstring) = component.split_at(idx);
+            components.push(name);
+            components.extend(indexstring.split_inclusive(']'));
+        } else {
+            components.push(component);
+        }
+    }
+
+    components
+}
+
+
 // find the address and type of the current component of a symbol name
 fn find_membertype<'a>(
     typeinfo: &'a TypeInfo,
-    components: Vec<&str>,
+    components: &Vec<&str>,
     component_index: usize,
     address: u64
 ) -> Option<(u64, &'a TypeInfo)> {
@@ -253,7 +283,8 @@ fn find_membertype<'a>(
             TypeInfo::Array { dim, stride, arraytype, .. } => {
                 let mut multi_index = 0;
                 for idx_pos in 0 .. dim.len() {
-                    let indexval = get_index(components[component_index + idx_pos])?;
+                    let arraycomponent = components.get(component_index + idx_pos)?;
+                    let indexval = get_index(arraycomponent)?;
                     multi_index = multi_index * dim[idx_pos] as usize + indexval;
                 }
 
@@ -271,7 +302,7 @@ fn find_membertype<'a>(
 }
 
 
-// for some reason array indices in symbol names in a2l files are not written as [x], but as _x_
+// before ASAP2 1.7 array indices in symbol names could not written as [x], but only as _x_
 // this function will get the numerical index for either representation
 fn get_index(idxstr: &str) -> Option<usize> {
     if (idxstr.starts_with('_') && idxstr.ends_with('_')) ||
@@ -338,3 +369,90 @@ impl UpdateSumary {
     }
 }
 
+#[test]
+fn test_split_symbol_components() {
+    let result = split_symbol_components("my_struct.array_field[5][1]");
+    assert_eq!(result.len(), 4);
+    assert_eq!(result[0], "my_struct");
+    assert_eq!(result[1], "array_field");
+    assert_eq!(result[2], "[5]");
+    assert_eq!(result[3], "[1]");
+
+    let result2 = split_symbol_components("my_struct.array_field._5_._1_");
+    assert_eq!(result2.len(), 4);
+    assert_eq!(result2[0], "my_struct");
+    assert_eq!(result2[1], "array_field");
+    assert_eq!(result2[2], "_5_");
+    assert_eq!(result2[3], "_1_");
+}
+
+#[test]
+fn test_find_symbol_of_array() {
+    let mut dbgdata = DebugData {
+        types: HashMap::new(),
+        variables: HashMap::new()
+    };
+    // global variable: uint32_t my_array[2]
+    dbgdata.variables.insert(
+        "my_array".to_string(),
+        crate::dwarf::VarInfo { address: 0x1234, typeref: 1 });
+    dbgdata.types.insert(
+        1,
+        TypeInfo::Array {
+            arraytype: Box::new(TypeInfo::Uint32),
+            dim: vec![2],
+            size: 8, // total size of the array
+            stride: 4
+        }
+    );
+
+    // try the different array indexing notations
+    let result1 = find_symbol("my_array._0_", &dbgdata);
+    assert!(result1.is_some());
+    // C-style notation is only allowed starting with ASAP2 version 1.7, before that the '[' and ']' are not allowed in names
+    let result3 = find_symbol("my_array[0]", &dbgdata);
+    assert!(result3.is_some());
+}
+
+
+#[test]
+fn test_find_symbol_of_array_in_struct() {
+    let mut dbgdata = DebugData {
+        types: HashMap::new(),
+        variables: HashMap::new()
+    };
+    // global variable defined in C like this:
+    // struct {
+    //        uint32_t array_item[2];
+    // } my_struct;
+    let mut structmembers: HashMap<String, (TypeInfo, u64)> = HashMap::new();
+    structmembers.insert(
+        "array_item".to_string(),
+        (
+            TypeInfo::Array {
+                arraytype: Box::new(TypeInfo::Uint32),
+                dim: vec![2],
+                size: 8,
+                stride: 4
+            },
+            0
+        )
+    );
+    dbgdata.variables.insert(
+        "my_struct".to_string(),
+        crate::dwarf::VarInfo { address: 0xcafe00, typeref: 2 });
+    dbgdata.types.insert(
+        2,
+        TypeInfo::Struct {
+            members: structmembers,
+            size: 4
+        }
+    );
+
+    // try the different array indexing notations
+    let result1 = find_symbol("my_struct.array_item._0_", &dbgdata);
+    assert!(result1.is_some());
+    // C-style notation is only allowed starting with ASAP2 version 1.7, before that the '[' and ']' are not allowed in names
+    let result3 = find_symbol("my_struct.array_item[0]", &dbgdata);
+    assert!(result3.is_some());
+}

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -204,7 +204,7 @@ fn get_symbol_name_from_ifdata(ifdata_vec: &Vec<IfData>) -> Option<String> {
 
 
 // find a symbol in the elf_info data structure that was derived from the DWARF debug info in the elf file
-fn find_symbol<'a>(varname: &str, debug_data: &'a DebugData) -> Option<(u64, &'a TypeInfo)> {
+pub(crate) fn find_symbol<'a>(varname: &str, debug_data: &'a DebugData) -> Option<(u64, &'a TypeInfo)> {
     // split the a2l symbol name: e.g. "motortune.param._0_" -> ["motortune", "param", "_0_"]
     let components = split_symbol_components(varname);
 


### PR DESCRIPTION
With files of version 1.7 and later, it becomes possible to use '[' and ']', but symbols
using these were not found correctly. The code incorrectly expected array names like
"some_array.[0]" instead of "some_array[0]"
