### PR TITLE
Enhance the DWARF debug info reading code

### DIFF
--- a/src/dwarf/typereader.rs
+++ b/src/dwarf/typereader.rs
@@ -8,7 +8,8 @@ use super::attributes::*;
 pub(crate) fn load_types(
     variables: &HashMap<String, VarInfo>,
     units: UnitList,
-    dwarf: &gimli::Dwarf<EndianSlice<RunTimeEndian>>
+    dwarf: &gimli::Dwarf<EndianSlice<RunTimeEndian>>,
+    verbose: bool
 ) -> HashMap<usize, TypeInfo> {
     let mut types = HashMap::<usize, TypeInfo>::new();
     // for each variable
@@ -23,8 +24,15 @@ pub(crate) fn load_types(
                 let mut entries_tree = unit.entries_tree(&abbrev, Some(unit_offset)).unwrap();
 
                 // load one type and add it to the collection (always succeeds for correctly structured DWARF debug info)
-                if let Some(vartype) = get_type(&units, unit_idx, entries_tree.root().unwrap(), None, dwarf) {
-                    types.insert(*typeref, vartype);
+                match get_type(&units, unit_idx, entries_tree.root().unwrap(), None, dwarf) {
+                    Ok(vartype) => {
+                        types.insert(*typeref, vartype);
+                    }
+                    Err(errmsg) => {
+                        if verbose {
+                            println!("Error loading type info for variable {}: {}", _name, errmsg);
+                        }
+                    }
                 }
             }
         }
@@ -41,13 +49,13 @@ fn get_type(
     entries_tree: EntriesTreeNode<EndianSlice<RunTimeEndian>>,
     typedef_name: Option<String>,
     dwarf: &gimli::Dwarf<EndianSlice<RunTimeEndian>>
-) -> Option<TypeInfo> {
+) -> Result<TypeInfo, String> {
     let entry = entries_tree.entry();
     match entry.tag() {
         gimli::constants::DW_TAG_base_type => {
             let byte_size = get_byte_size_attribute(entry).unwrap_or(1u64);
             let encoding = get_encoding_attribute(entry).unwrap_or(gimli::constants::DW_ATE_unsigned);
-            Some(match encoding {
+            Ok(match encoding {
                 gimli::constants::DW_ATE_address => {
                     let (unit, _) = &unit_list[current_unit];
                     TypeInfo::Pointer(unit.encoding().address_size as u64)
@@ -66,9 +74,8 @@ fn get_type(
                         2 => TypeInfo::Sint16,
                         4 => TypeInfo::Sint32,
                         8 => TypeInfo::Sint64,
-                        _val => {
-                            // println!("signed integer base type of unusual size {} found - cannot represent in output", _val);
-                            return None;
+                        val => {
+                            return Err(format!("error loading data type: signed int of size {}", val));
                         }
                     }
                 }
@@ -80,63 +87,62 @@ fn get_type(
                         2 => TypeInfo::Uint16,
                         4 => TypeInfo::Uint32,
                         8 => TypeInfo::Uint64,
-                        _val => {
-                            // println!("unsigned integer base type of unusual size {} found - cannot represent in output", _val);
-                            return None;
+                        val => {
+                            return Err(format!("error loading data type: unsigned int of size {}", val));
                         }
                     }
                 }
                 _other => {
-                    //println!("unknown base type encoding {:#?} found, using uint8", other);
                     TypeInfo::Other(byte_size)
                 }
             })
         }
         gimli::constants::DW_TAG_pointer_type => {
             let (unit, _) = &unit_list[current_unit];
-            Some(TypeInfo::Pointer(unit.encoding().address_size as u64))
+            Ok(TypeInfo::Pointer(unit.encoding().address_size as u64))
         }
         gimli::constants::DW_TAG_array_type => {
-            let size = get_byte_size_attribute(entry)?;
-            let (new_cur_unit, mut new_entries_tree) = get_entries_tree_from_attribute(entry, unit_list, current_unit)?;
-            if let Some(arraytype) = get_type(
-                unit_list,
+            let size = get_byte_size_attribute(entry)
+                .ok_or_else(|| "error decoding array info: missing size attribute".to_string())?;
+            let (new_cur_unit, mut new_entries_tree) =
+                get_entries_tree_from_attribute(entry, unit_list, current_unit)?;
+            let arraytype = get_type(unit_list,
                 new_cur_unit,
                 new_entries_tree.root().unwrap(),
                 None,
-                dwarf
-            ) {
-                let mut dim = Vec::<u64>::new();
-    
-                // If the stride of the array is different from the size of each element, then the stride must be given as an attribute
-                let stride = if let Some(stride) = get_byte_stride_attribute(entry) {
-                    stride
-                } else {
-                    // this is the usual case
-                    arraytype.get_size()
-                };
-    
-                // the child entries of the DW_TAG_array_type entry give the array dimensions
-                let mut iter = entries_tree.children();
-                while let Ok(Some(child_node)) = iter.next() {
-                    let child_entry = child_node.entry();
-                    if child_entry.tag() ==  gimli::constants::DW_TAG_subrange_type {
-                        let ubound = get_upper_bound_attribute(child_entry)?;
-                        dim.push(ubound + 1);
-                    }
-                }
-                Some(TypeInfo::Array { dim, arraytype: Box::new(arraytype), size, stride })
+                dwarf)?;
+
+            let mut dim = Vec::<u64>::new();
+
+            // If the stride of the array is different from the size of each element, then the stride must be given as an attribute
+            let stride = if let Some(stride) = get_byte_stride_attribute(entry) {
+                stride
             } else {
-                None
+                // this is the usual case
+                arraytype.get_size()
+            };
+
+            let default_ubound = (size / stride) - 1; // subtract 1, because ubound is the last element, not the size
+
+            // the child entries of the DW_TAG_array_type entry give the array dimensions
+            let mut iter = entries_tree.children();
+            while let Ok(Some(child_node)) = iter.next() {
+                let child_entry = child_node.entry();
+                if child_entry.tag() ==  gimli::constants::DW_TAG_subrange_type {
+                    let ubound = get_upper_bound_attribute(child_entry).unwrap_or(default_ubound);
+                    dim.push(ubound + 1);
+                }
             }
+            Ok(TypeInfo::Array { dim, arraytype: Box::new(arraytype), size, stride })
         }
         gimli::constants::DW_TAG_enumeration_type => {
-            let size = get_byte_size_attribute(entry)?;
+            let size = get_byte_size_attribute(entry)
+                .ok_or_else(|| "missing enum byte size attribute".to_string())?;
             let mut enumerators = Vec::new();
             let typename = if let Some(name) = typedef_name {
                 name
             } else {
-                if let Some(name_from_attr) = get_name_attribute(entry, dwarf) {
+                if let Ok(name_from_attr) = get_name_attribute(entry, dwarf) {
                     name_from_attr
                 } else {
                     let (unit, _) = &unit_list[current_unit];
@@ -148,47 +154,32 @@ fn get_type(
             while let Ok(Some(child_node)) = iter.next() {
                 let child_entry = child_node.entry();
                 if child_entry.tag() ==  gimli::constants::DW_TAG_enumerator {
-                    let name = get_name_attribute(child_entry, dwarf)?;
-                    let value = get_const_value_attribute(child_entry)?;
+                    let name = get_name_attribute(child_entry, dwarf)
+                        .map_err(|_| "missing enum item name".to_string() )?;
+                    let value = get_const_value_attribute(child_entry)
+                        .ok_or_else(|| "missing enum item value".to_string())?;
                     enumerators.push((name, value));
                 }
             }
-            Some(TypeInfo::Enum { typename, size, enumerators })
+            Ok(TypeInfo::Enum { typename, size, enumerators })
         }
         gimli::constants::DW_TAG_structure_type => {
-            let size = get_byte_size_attribute(entry)?;
-            /*let typename = if let Some(name) = typedef_name {
-                name
-            } else {
-                if let Some(name_from_attr) = get_name_attribute(entry, dwarf) {
-                    name_from_attr
-                } else {
-                    let (unit, _) = &unit_list[current_unit];
-                    format!("anonymous_struct_{}", entry.offset().to_debug_info_offset(unit).unwrap().0)
-                }
-            };*/
+            let size = get_byte_size_attribute(entry)
+                .ok_or_else(|| "missing struct byte size attribute".to_string())?;
             let members = get_struct_or_union_members(entries_tree, unit_list, current_unit, dwarf)?;
-            Some(TypeInfo::Struct {/*typename,*/ size, members})
+            Ok(TypeInfo::Struct {size, members})
         }
         gimli::constants::DW_TAG_class_type => {
-            let size = get_byte_size_attribute(entry)?;
-            /*let typename = if let Some(name) = typedef_name {
-                name
-            } else {
-                if let Some(name_from_attr) = get_name_attribute(entry, dwarf) {
-                    name_from_attr
-                } else {
-                    let (unit, _) = &unit_list[current_unit];
-                    format!("anonymous_class_{}", entry.offset().to_debug_info_offset(unit).unwrap().0)
-                }
-            };*/
+            let size = get_byte_size_attribute(entry)
+                .ok_or_else(|| "missing class byte size attribute".to_string())?;
             let members = get_struct_or_union_members(entries_tree, unit_list, current_unit, dwarf)?;
-            Some(TypeInfo::Class {/*typename,*/ size, members})
+            Ok(TypeInfo::Class {size, members})
         }
         gimli::constants::DW_TAG_union_type => {
-            let size = get_byte_size_attribute(entry)?;
+            let size = get_byte_size_attribute(entry)
+                .ok_or_else(|| "missing union byte size attribute".to_string())?;
             let members = get_struct_or_union_members(entries_tree, unit_list, current_unit, dwarf)?;
-            Some(TypeInfo::Union {size, members})
+            Ok(TypeInfo::Union {size, members})
         }
         gimli::constants::DW_TAG_typedef => {
             let name = get_name_attribute(entry, dwarf)?;
@@ -213,8 +204,7 @@ fn get_type(
             )
         }
         other_tag => {
-            println!("unexpected DWARF tag {} in type definition", other_tag);
-            None
+            Err(format!("unexpected DWARF tag {} in type definition", other_tag))
         }
     }
 }
@@ -226,15 +216,17 @@ fn get_struct_or_union_members(
     unit_list: &UnitList,
     current_unit: usize,
     dwarf: &gimli::Dwarf<EndianSlice<RunTimeEndian>>
-) -> Option<HashMap<String, (TypeInfo, u64)>> {
+) -> Result<HashMap<String, (TypeInfo, u64)>, String> {
     let (unit, _) = &unit_list[current_unit];
     let mut members = HashMap::<String, (TypeInfo, u64)>::new();
     let mut iter = entries_tree.children();
     while let Ok(Some(child_node)) = iter.next() {
         let child_entry = child_node.entry();
         if child_entry.tag() == gimli::constants::DW_TAG_member {
-            let name = get_name_attribute(child_entry, dwarf)?;
-            let offset = get_data_member_location_attribute(child_entry, unit.encoding())?;
+            let name = get_name_attribute(child_entry, dwarf)
+                .map_err(|_| "missing struct/union member name".to_string())?;
+            let offset = get_data_member_location_attribute(child_entry, unit.encoding())
+                .ok_or_else(|| "missing byte offset for struct/union member".to_string())?;
             let bitsize = get_bit_size_attribute(child_entry);
             let bitoffset = get_bit_offset_attribute(child_entry);
             let (new_cur_unit, mut new_entries_tree) =
@@ -260,5 +252,5 @@ fn get_struct_or_union_members(
             members.insert(name, (membertype, offset));
         }
     }
-    Some(members)
+    Ok(members)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ fn core() -> Result<(), String> {
     // load elf
     let elf_info = if arg_matches.is_present("ELFFILE") {
         let elffile = arg_matches.value_of_os("ELFFILE").unwrap();
-        let elf_info = load_debuginfo(elffile)?;
+        let elf_info = load_debuginfo(elffile, verbose > 0)?;
         cond_print!(verbose, now, format!("Variables and types loaded from \"{}\": {} variables available", elffile.to_string_lossy(), elf_info.variables.len()));
         if debugprint {
             println!("================\n{:#?}\n================\n", elf_info);


### PR DESCRIPTION
 - return Result instead of Option in many functions, propagating error info.
 - print errors that occur during reading
 - do not treat a missing DW_AT_upper_bound attribute in an array type as an error.
   This attribute is optional in the DWARF spec. If the upper bound is not given
   explicitly it is calculated based on the array size and element stride
 - handle the case where one debug info entry includes another using a
   DW_AT_abstract_origin attribute

Fixes issue #1 