### PR TITLE
add error messages to the address update procedure

### DIFF
--- a/src/insert.rs
+++ b/src/insert.rs
@@ -42,9 +42,9 @@ fn insert_measurement(
     sym_map: &HashMap<String, ItemType>
 ) {
     // get info about the symbol from the debug data
-    let findresult = crate::update::find_symbol(measure_sym, debugdata);
-    if findresult.is_none() {
-        println!("Symbol {} was not found in the elf file. It cannot be added.", measure_sym);
+    let findresult = crate::symbol::find_symbol(measure_sym, debugdata);
+    if let Err(errmsg) = findresult {
+        println!("Symbol {} could not be added: {}", measure_sym, errmsg);
         return;
     }
     let (address, typeinfo) = findresult.unwrap();
@@ -123,9 +123,9 @@ fn insert_characteristic(
     name_map: &HashMap<String, ItemType>,
     sym_map: &HashMap<String, ItemType>
 ) {
-    let findresult = crate::update::find_symbol(characteristic_sym, debugdata);
-    if findresult.is_none() {
-        println!("Symbol {} was not found in the elf file. It cannot be added.", characteristic_sym);
+    let findresult = crate::symbol::find_symbol(characteristic_sym, debugdata);
+    if let Err(errmsg) = findresult {
+        println!("Symbol {} could not be added: {}", characteristic_sym, errmsg);
         return;
     }
     let (address, typeinfo) = findresult.unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod update;
 mod insert;
 mod xcp;
 mod datatype;
+mod symbol;
 
 
 macro_rules! cond_print {
@@ -148,7 +149,12 @@ fn core() -> Result<(), String> {
     // update addresses
     if arg_matches.is_present("UPDATE") || arg_matches.is_present("SAFE_UPDATE") {
         let preserve_unknown = arg_matches.is_present("SAFE_UPDATE");
-        let summary = update::update_addresses(&mut a2l_file, &elf_info.as_ref().unwrap(), preserve_unknown);
+        let mut log_msgs = Vec::<String>::new();
+        let summary = update::update_addresses(&mut a2l_file, &elf_info.as_ref().unwrap(), &mut log_msgs, preserve_unknown);
+
+        for msg in log_msgs {
+            cond_print!(verbose, now, msg);
+        }
 
         cond_print!(verbose, now, format!("Address update done\nSummary:"));
         cond_print!(verbose, now, format!("   characteristic: {} updated, {} not found", summary.characteristic_updated, summary.characteristic_not_updated));

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -1,0 +1,241 @@
+use super::dwarf::{DebugData, TypeInfo};
+
+#[cfg(test)]
+use std::collections::HashMap;
+
+
+// find a symbol in the elf_info data structure that was derived from the DWARF debug info in the elf file
+pub(crate) fn find_symbol<'a>(varname: &str, debug_data: &'a DebugData) -> Result<(u64, &'a TypeInfo), String> {
+    // split the a2l symbol name: e.g. "motortune.param._0_" -> ["motortune", "param", "_0_"]
+    let components = split_symbol_components(varname);
+
+    // find the symbol in the symbol table
+    find_symbol_from_components(&components, debug_data)
+}
+
+
+fn find_symbol_from_components<'a>(components: &Vec<&str>, debug_data: &'a DebugData) -> Result<(u64, &'a TypeInfo), String> {
+    // the first component of the symbol name is the name of the global variable.
+    if let Some(varinfo) = debug_data.variables.get(components[0]) {
+        // we also need the type in order to resolve struct members, etc.
+        if let Some(vartype) = debug_data.types.get(&varinfo.typeref) {
+            // all further components of the symbol name are struct/union members or array indices
+            find_membertype(vartype, components, 1, varinfo.address)
+        } else {
+            // this exists for completeness, but shouldn't happen with a correctly generated elffile
+            // if the variable is present in the elffile, then the type should also be present
+            if components.len() == 1 {
+                Ok((varinfo.address, &TypeInfo::Uint8))
+            } else {
+                Err(format!("Remaining portion \"{}\" of \"{}\" could not be matched",
+                    components[1..].join("."),
+                    components.join(".")))
+            }
+        }
+    } else {
+        Err(format!("Symbol \"{}\" does not exist", components[0]))
+    }
+}
+
+
+// split the symbol into components
+// e.g. "my_struct.array_field[5][6]" -> [ "my_struct", "array_field", "[5]", "[6]" ]
+fn split_symbol_components(varname: &str) -> Vec<&str> {
+    let mut components: Vec<&str> = Vec::new();
+
+    for component in varname.split('.') {
+        if let Some(idx) = component.find('[') {
+            // "array_field[5][6]" -> "array_field", "[5][6]"
+            let (name, indexstring) = component.split_at(idx);
+            components.push(name);
+            components.extend(indexstring.split_inclusive(']'));
+        } else {
+            components.push(component);
+        }
+    }
+
+    components
+}
+
+
+// find the address and type of the current component of a symbol name
+fn find_membertype<'a>(
+    typeinfo: &'a TypeInfo,
+    components: &Vec<&str>,
+    component_index: usize,
+    address: u64
+) -> Result<(u64, &'a TypeInfo), String> {
+    if component_index >= components.len() {
+        Ok((address, typeinfo))
+    } else {
+        match typeinfo {
+            TypeInfo::Class { members, .. } |
+            TypeInfo::Struct { members, .. } |
+            TypeInfo::Union { members, .. } => {
+                if let Some((membertype, offset)) = members.get(components[component_index]) {
+                    find_membertype(
+                        membertype,
+                        components,
+                        component_index + 1,
+                        address + offset
+                    )
+                } else {
+                    Err(format!("There is no member \"{}\" in \"{}\"",
+                        components[component_index], components[..component_index].join(".")))
+                }
+            }
+            TypeInfo::Array { dim, stride, arraytype, .. } => {
+                let mut multi_index = 0;
+                for idx_pos in 0 .. dim.len() {
+                    let arraycomponent = components.get(component_index + idx_pos)
+                        .unwrap_or_else(|| &"_0_"); // default to first element if no more components are specified
+                    let indexval = get_index(arraycomponent)
+                        .ok_or_else(|| format!("could not interpret \"{}\" as an array index", arraycomponent))?;
+                    if indexval >= dim[idx_pos] as usize {
+                        return Err(format!("requested array index {} in expression \"{}\", but the array only has {} elements",
+                            indexval, components.join("."), dim[idx_pos]));
+                    }
+                    multi_index = multi_index * dim[idx_pos] as usize + indexval;
+                }
+
+                let elementaddr = address + (multi_index as u64 * stride);
+                find_membertype(
+                    arraytype,
+                    components,
+                    component_index + dim.len(),
+                    elementaddr
+                )
+            }
+            _ => {
+                if component_index >= components.len() {
+                    Ok((address, typeinfo))
+                } else {
+                    // could not descend further to match additional symbol name components
+                    Err(format!("Remaining portion \"{}\" of \"{}\" could not be matched",
+                        components[component_index..].join("."),
+                        components.join(".")))
+                }
+            }
+        }
+    }
+}
+
+
+// before ASAP2 1.7 array indices in symbol names could not written as [x], but only as _x_
+// this function will get the numerical index for either representation
+fn get_index(idxstr: &str) -> Option<usize> {
+    if (idxstr.starts_with('_') && idxstr.ends_with('_')) ||
+       (idxstr.starts_with('[') && idxstr.ends_with(']')) {
+        let idxstrlen = idxstr.len();
+        match idxstr[1..idxstrlen-1].parse() {
+            Ok(val) => Some(val),
+            Err(_) => None
+        }
+    } else {
+        None
+    }
+}
+
+#[test]
+fn test_split_symbol_components() {
+    let result = split_symbol_components("my_struct.array_field[5][1]");
+    assert_eq!(result.len(), 4);
+    assert_eq!(result[0], "my_struct");
+    assert_eq!(result[1], "array_field");
+    assert_eq!(result[2], "[5]");
+    assert_eq!(result[3], "[1]");
+
+    let result2 = split_symbol_components("my_struct.array_field._5_._1_");
+    assert_eq!(result2.len(), 4);
+    assert_eq!(result2[0], "my_struct");
+    assert_eq!(result2[1], "array_field");
+    assert_eq!(result2[2], "_5_");
+    assert_eq!(result2[3], "_1_");
+}
+
+
+#[test]
+fn test_find_symbol_of_array() {
+    let mut dbgdata = DebugData {
+        types: HashMap::new(),
+        variables: HashMap::new()
+    };
+    // global variable: uint32_t my_array[2]
+    dbgdata.variables.insert(
+        "my_array".to_string(),
+        crate::dwarf::VarInfo { address: 0x1234, typeref: 1 });
+    dbgdata.types.insert(
+        1,
+        TypeInfo::Array {
+            arraytype: Box::new(TypeInfo::Uint32),
+            dim: vec![2],
+            size: 8, // total size of the array
+            stride: 4
+        }
+    );
+
+    // try the different array indexing notations
+    let result1 = find_symbol("my_array._0_", &dbgdata);
+    assert!(result1.is_ok());
+    // C-style notation is only allowed starting with ASAP2 version 1.7, before that the '[' and ']' are not allowed in names
+    let result2 = find_symbol("my_array[0]", &dbgdata);
+    assert!(result2.is_ok());
+
+    // it should also be possible to get a typeref for the entire array
+    let result3 = find_symbol("my_array", &dbgdata);
+    assert!(result3.is_ok());
+
+    // there should not be a result if the symbol name contains extra unmatched components
+    let result4 = find_symbol("my_array._0_.lalala", &dbgdata);
+    assert!(result4.is_err());
+    // going past the end of the array is also not permitted
+    let result5 = find_symbol("my_array._2_", &dbgdata);
+    assert!(result5.is_err());
+}
+
+
+#[test]
+fn test_find_symbol_of_array_in_struct() {
+    let mut dbgdata = DebugData {
+        types: HashMap::new(),
+        variables: HashMap::new()
+    };
+    // global variable defined in C like this:
+    // struct {
+    //        uint32_t array_item[2];
+    // } my_struct;
+    let mut structmembers: HashMap<String, (TypeInfo, u64)> = HashMap::new();
+    structmembers.insert(
+        "array_item".to_string(),
+        (
+            TypeInfo::Array {
+                arraytype: Box::new(TypeInfo::Uint32),
+                dim: vec![2],
+                size: 8,
+                stride: 4
+            },
+            0
+        )
+    );
+    dbgdata.variables.insert(
+        "my_struct".to_string(),
+        crate::dwarf::VarInfo { address: 0xcafe00, typeref: 2 });
+    dbgdata.types.insert(
+        2,
+        TypeInfo::Struct {
+            members: structmembers,
+            size: 4
+        }
+    );
+
+    // try the different array indexing notations
+    let result1 = find_symbol("my_struct.array_item._0_", &dbgdata);
+    assert!(result1.is_ok());
+    // C-style notation is only allowed starting with ASAP2 version 1.7, before that the '[' and ']' are not allowed in names
+    let result2 = find_symbol("my_struct.array_item[0]", &dbgdata);
+    assert!(result2.is_ok());
+
+    // theres should not be a result if the symbol name contains extra unmatched components
+    let result3 = find_symbol("my_struct.array_item._0_.extra.unused", &dbgdata);
+    assert!(result3.is_err());
+}

--- a/src/update/axis_pts.rs
+++ b/src/update/axis_pts.rs
@@ -11,6 +11,7 @@ use super::*;
 pub(crate) fn update_module_axis_pts(
     module: &mut Module,
     debug_data: &DebugData,
+    log_msgs: &mut Vec<String>,
     preserve_unknown: bool,
     recordlayout_info: &mut RecordLayoutInfo
 ) -> (u32, u32) {
@@ -22,64 +23,69 @@ pub(crate) fn update_module_axis_pts(
 
     std::mem::swap(&mut module.axis_pts, &mut axis_pts_list);
     for mut axis_pts in axis_pts_list {
-        if let Some(typeinfo) = update_axis_pts_address(&mut axis_pts, debug_data) {
-            // the variable used for the axis should be a 1-dimensional array, or a struct containing a 1-dimensional array
-            // if the type is a struct, then the AXIS_PTS_X inside the referenced RECORD_LAYOUT tells us which member of the struct to use.
-            let member_id = get_axis_pts_x_memberid(module, recordlayout_info, &axis_pts.deposit_record);
-            if let Some(inner_typeinfo) = get_inner_type(typeinfo, member_id) {
+        match update_axis_pts_address(&mut axis_pts, debug_data) {
+            Ok(typeinfo) => {
+                // the variable used for the axis should be a 1-dimensional array, or a struct containing a 1-dimensional array
+                // if the type is a struct, then the AXIS_PTS_X inside the referenced RECORD_LAYOUT tells us which member of the struct to use.
+                let member_id = get_axis_pts_x_memberid(module, recordlayout_info, &axis_pts.deposit_record);
+                if let Some(inner_typeinfo) = get_inner_type(typeinfo, member_id) {
 
-                match inner_typeinfo {
-                    TypeInfo::Array{dim, arraytype, ..} => {
-                        // update max_axis_points to match the size of the array
-                        if dim.len() >= 1 {
-                            axis_pts.max_axis_points = dim[0] as u16;
-                        }
-                        if let TypeInfo::Enum{typename, enumerators, ..} = &**arraytype {
-                            // an array of enums? it could be done...
-                            if axis_pts.conversion == "NO_COMPU_METHOD" {
-                                axis_pts.conversion = typename.to_owned();
+                    match inner_typeinfo {
+                        TypeInfo::Array{dim, arraytype, ..} => {
+                            // update max_axis_points to match the size of the array
+                            if dim.len() >= 1 {
+                                axis_pts.max_axis_points = dim[0] as u16;
                             }
-                            cond_create_enum_conversion(module, &axis_pts.conversion, enumerators);
-                            enum_convlist.insert(axis_pts.conversion.clone(), arraytype);
+                            if let TypeInfo::Enum{typename, enumerators, ..} = &**arraytype {
+                                // an array of enums? it could be done...
+                                if axis_pts.conversion == "NO_COMPU_METHOD" {
+                                    axis_pts.conversion = typename.to_owned();
+                                }
+                                cond_create_enum_conversion(module, &axis_pts.conversion, enumerators);
+                                enum_convlist.insert(axis_pts.conversion.clone(), arraytype);
+                            }
                         }
+                        TypeInfo::Enum{..} => {
+                            // likely not useful, because what purpose would an axis consisting of a single enum value serve?
+                            enum_convlist.insert(axis_pts.conversion.clone(), typeinfo);
+                        }
+                        _ => {}
                     }
-                    TypeInfo::Enum{..} => {
-                        // likely not useful, because what purpose would an axis consisting of a single enum value serve?
-                        enum_convlist.insert(axis_pts.conversion.clone(), typeinfo);
-                    }
-                    _ => {}
+
+                    let (ll, ul) = adjust_limits(
+                        inner_typeinfo,
+                        axis_pts.lower_limit,
+                        axis_pts.upper_limit
+                    );
+                    axis_pts.lower_limit = ll;
+                    axis_pts.upper_limit = ul;
                 }
 
-                let (ll, ul) = adjust_limits(
-                    inner_typeinfo,
-                    axis_pts.lower_limit,
-                    axis_pts.upper_limit
+                // update the data type in the referenced RECORD_LAYOUT
+                axis_pts.deposit_record = update_record_layout(
+                    module,
+                    recordlayout_info,
+                    &axis_pts.deposit_record,
+                    typeinfo
                 );
-                axis_pts.lower_limit = ll;
-                axis_pts.upper_limit = ul;
-            }
 
-            // update the data type in the referenced RECORD_LAYOUT
-            axis_pts.deposit_record = update_record_layout(
-                module,
-                recordlayout_info,
-                &axis_pts.deposit_record,
-                typeinfo
-            );
-
-            // put the updated AXIS_PTS back on the module's list
-            module.axis_pts.push(axis_pts);
-            axis_pts_updated += 1;
-        } else {
-            if preserve_unknown {
-                axis_pts.address = 0;
-                zero_if_data(&mut axis_pts.if_data);
+                // put the updated AXIS_PTS back on the module's list
                 module.axis_pts.push(axis_pts);
-            } else {
-                // item is removed implicitly, because it is not added back to the list
-                removed_items.insert(axis_pts.name.to_owned());
+                axis_pts_updated += 1;
             }
-            axis_pts_not_updated += 1;
+            Err(errmsgs) => {
+                log_update_errors(log_msgs, errmsgs, "AXIS_PTS", axis_pts.get_line());
+
+                if preserve_unknown {
+                    axis_pts.address = 0;
+                    zero_if_data(&mut axis_pts.if_data);
+                    module.axis_pts.push(axis_pts);
+                } else {
+                    // item is removed implicitly, because it is not added back to the list
+                    removed_items.insert(axis_pts.name.to_owned());
+                }
+                axis_pts_not_updated += 1;
+            }
         }
     }
 
@@ -95,22 +101,21 @@ pub(crate) fn update_module_axis_pts(
 fn update_axis_pts_address<'a>(
     axis_pts: &mut AxisPts,
     debug_data: &'a DebugData
-) -> Option<&'a TypeInfo> {
-    let (symbol_info, symbol_name) = get_symbol_info(
+) -> Result<&'a TypeInfo, Vec<String>> {
+    match get_symbol_info(
         &axis_pts.name,
         &axis_pts.symbol_link,
         &axis_pts.if_data, debug_data
-    );
+    ) {
+        Ok((address, symbol_datatype, symbol_name)) => {
+            // make sure a valid SYMBOL_LINK exists
+            set_symbol_link(&mut axis_pts.symbol_link, symbol_name.clone());
+            axis_pts.address = address as u32;
+            update_ifdata(&mut axis_pts.if_data, symbol_name, symbol_datatype, address);
 
-    if let Some((address, symbol_datatype)) = symbol_info {
-        // make sure a valid SYMBOL_LINK exists
-        set_symbol_link(&mut axis_pts.symbol_link, symbol_name.clone());
-        axis_pts.address = address as u32;
-        update_ifdata(&mut axis_pts.if_data, symbol_name, symbol_datatype, address);
-
-        Some(symbol_datatype)
-    } else {
-        None
+            Ok(symbol_datatype)
+        }
+        Err(errmsgs) => Err(errmsgs)
     }
 }
 

--- a/src/update/blob.rs
+++ b/src/update/blob.rs
@@ -9,6 +9,7 @@ use super::*;
 pub(crate) fn update_module_blobs(
     module: &mut Module,
     debug_data: &DebugData,
+    log_msgs: &mut Vec<String>,
     preserve_unknown: bool
 ) -> (u32, u32) {
     let mut removed_items = HashSet::<String>::new();
@@ -17,20 +18,25 @@ pub(crate) fn update_module_blobs(
     let mut blob_not_updated: u32 = 0;
     std::mem::swap(&mut module.blob, &mut blob_list);
     for mut blob in blob_list {
-        if let Some(typeinfo) = update_blob_address(&mut blob, debug_data) {
-            blob.size = typeinfo.get_size() as u32;
-            module.blob.push(blob);
-            blob_updated += 1;
-        } else {
-            if preserve_unknown {
-                blob.start_address = 0;
-                zero_if_data(&mut blob.if_data);
+        match update_blob_address(&mut blob, debug_data) {
+            Ok(typeinfo) => {
+                blob.size = typeinfo.get_size() as u32;
                 module.blob.push(blob);
-            } else {
-                // item is removed implicitly, because it is not added back to the list
-                removed_items.insert(blob.name.to_owned());
+                blob_updated += 1;
             }
-            blob_not_updated += 1;
+            Err(errmsgs) => {
+                log_update_errors(log_msgs, errmsgs, "BLOB", blob.get_line());
+
+                if preserve_unknown {
+                    blob.start_address = 0;
+                    zero_if_data(&mut blob.if_data);
+                    module.blob.push(blob);
+                } else {
+                    // item is removed implicitly, because it is not added back to the list
+                    removed_items.insert(blob.name.to_owned());
+                }
+                blob_not_updated += 1;
+            }
         }
     }
     cleanup_removed_blobs(module, &removed_items);
@@ -40,19 +46,17 @@ pub(crate) fn update_module_blobs(
 
 
 // update the address of a BLOB object
-fn update_blob_address<'a>(blob: &mut Blob, debug_data: &'a DebugData) -> Option<&'a TypeInfo> {
-    let (symbol_info, symbol_name) =
-        get_symbol_info(&blob.name, &blob.symbol_link, &blob.if_data, debug_data);
+fn update_blob_address<'a>(blob: &mut Blob, debug_data: &'a DebugData) -> Result<&'a TypeInfo, Vec<String>> {
+    match get_symbol_info(&blob.name, &blob.symbol_link, &blob.if_data, debug_data) {
+        Ok((address, symbol_datatype, symbol_name)) => {
+            // make sure a valid SYMBOL_LINK exists
+            set_symbol_link(&mut blob.symbol_link, symbol_name.clone());
+            blob.start_address = address as u32;
+            update_ifdata(&mut blob.if_data, symbol_name, symbol_datatype, address);
 
-    if let Some((address, symbol_datatype)) = symbol_info {
-        // make sure a valid SYMBOL_LINK exists
-        set_symbol_link(&mut blob.symbol_link, symbol_name.clone());
-        blob.start_address = address as u32;
-        update_ifdata(&mut blob.if_data, symbol_name, symbol_datatype, address);
-
-        Some(symbol_datatype)
-    } else {
-        None
+            Ok(symbol_datatype)
+        }
+        Err(errmsgs) => Err(errmsgs)
     }
 }
 

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -3,9 +3,6 @@ use super::ifdata;
 use a2lfile::*;
 use std::collections::HashSet;
 
-#[cfg(test)]
-use std::collections::HashMap;
-
 mod axis_pts;
 mod blob;
 mod characteristic;
@@ -16,6 +13,7 @@ mod measurement;
 mod record_layout;
 
 use crate::datatype::*;
+use crate::symbol::*;
 use axis_pts::*;
 use blob::*;
 use characteristic::*;
@@ -43,6 +41,7 @@ pub(crate) struct UpdateSumary {
 pub(crate) fn update_addresses(
     a2l_file: &mut A2lFile,
     debug_data: &DebugData,
+    log_msgs: &mut Vec<String>,
     preserve_unknown: bool
 ) -> UpdateSumary {
     let use_new_matrix_dim = check_version_1_70(a2l_file);
@@ -55,6 +54,7 @@ pub(crate) fn update_addresses(
         let (updated, not_updated) = update_module_axis_pts(
             module,
             debug_data,
+            log_msgs,
             preserve_unknown,
             &mut reclayout_info
         );
@@ -65,6 +65,7 @@ pub(crate) fn update_addresses(
         let (updated, not_updated) = update_module_measurements(
             module,
             debug_data,
+            log_msgs,
             preserve_unknown,
             use_new_matrix_dim
         );
@@ -75,6 +76,7 @@ pub(crate) fn update_addresses(
         let (updated, not_updated) = update_module_characteristics(
             module,
             debug_data,
+            log_msgs,
             preserve_unknown,
             &mut reclayout_info
         );
@@ -85,6 +87,7 @@ pub(crate) fn update_addresses(
         let (updated, not_updated) = update_module_blobs(
             module,
             debug_data,
+            log_msgs,
             preserve_unknown
         );
         summary.blob_updated += updated;
@@ -94,6 +97,7 @@ pub(crate) fn update_addresses(
         let (updated, not_updated) = update_module_instances(
             module,
             debug_data,
+            log_msgs,
             preserve_unknown
         );
         summary.blob_updated += updated;
@@ -120,33 +124,68 @@ fn get_symbol_info<'a>(
     opt_symbol_link: &Option<SymbolLink>,
     ifdata_vec: &Vec<IfData>,
     debug_data: &'a DebugData
-) -> (Option<(u64, &'a TypeInfo)>, String) {
-    let mut symbol_info = None;
-    let mut symbol_name = "".to_string();
-
+) -> Result<(u64, &'a TypeInfo, String), Vec<String>> {
+    let mut symbol_link_errmsg = None;
+    let mut ifdata_errmsg = None;
+    let mut object_name_errmsg = None;
     // preferred: get symbol information from a SYMBOL_LINK attribute
     if let Some(symbol_link) = opt_symbol_link {
-        symbol_name = symbol_link.symbol_name.clone();
-        symbol_info = find_symbol(&symbol_name, debug_data);
+        match find_symbol(&symbol_link.symbol_name, debug_data) {
+            Ok((addr, typeinfo)) => {
+                return Ok((addr, typeinfo, symbol_link.symbol_name.clone()))
+            }
+            Err(errmsg) => symbol_link_errmsg = Some(errmsg)
+        };
     }
 
     // second option: get symbol information from a CANAPE_EXT block inside of IF_DATA.
     // The content of IF_DATA can be different for each tool vendor, but the blocks used
     // by the Vector tools are understood by some other software.
-    if symbol_info.is_none() {
-        if let Some(ifdata_symbol_name) = get_symbol_name_from_ifdata(ifdata_vec) {
-            symbol_name = ifdata_symbol_name;
-            symbol_info = find_symbol(&symbol_name, debug_data);
-        }
+    if let Some(ifdata_symbol_name) = get_symbol_name_from_ifdata(ifdata_vec) {
+        match find_symbol(&ifdata_symbol_name, debug_data) {
+            Ok((addr, typeinfo)) => {
+                return Ok((addr, typeinfo, ifdata_symbol_name))
+            }
+            Err(errmsg) => ifdata_errmsg = Some(errmsg)
+        };
     }
 
-    // If there is no SYMBOL_LINK and no (usable) IF_DATA, then maybe the object name is also the symol name
-    if symbol_info.is_none() && opt_symbol_link.is_none() {
-        symbol_name = name.to_string();
-        symbol_info = find_symbol(&symbol_name, debug_data);
+    // If there is no SYMBOL_LINK and no (usable) IF_DATA, then maybe the object name is also the symbol name
+    if opt_symbol_link.is_none() {
+        match find_symbol(&name, debug_data) {
+            Ok((addr, typeinfo)) => {
+                return Ok((addr, typeinfo, name.to_string()))
+            }
+            Err(errmsg) => object_name_errmsg = Some(errmsg)
+        };
     }
     
-    (symbol_info, symbol_name)
+    // all attempts to get a matching symbol from the debug info have failed
+    // construct an array of (unique) error messages
+    let mut errorstrings = Vec::<String>::new();
+    if let Some(errmsg) = symbol_link_errmsg {
+        errorstrings.push(errmsg)
+    }
+    if let Some(errmsg) = ifdata_errmsg {
+        // no duplicates wanted
+        if !errorstrings.contains(&errmsg) {
+            errorstrings.push(errmsg)
+        }
+    }
+    if let Some(errmsg) = object_name_errmsg {
+        // no duplicates wanted
+        if !errorstrings.contains(&errmsg) {
+            errorstrings.push(errmsg)
+        }
+    }
+    Err(errorstrings)
+}
+
+
+fn log_update_errors(errorlog: &mut Vec<String>, errmsgs: Vec<String>, blockname: &str, line: u32) {
+    for msg in errmsgs {
+        errorlog.push(format!("Error updating {} on line {}: {}", blockname, line, msg));
+    }
 }
 
 
@@ -203,119 +242,6 @@ fn get_symbol_name_from_ifdata(ifdata_vec: &Vec<IfData>) -> Option<String> {
 }
 
 
-// find a symbol in the elf_info data structure that was derived from the DWARF debug info in the elf file
-pub(crate) fn find_symbol<'a>(varname: &str, debug_data: &'a DebugData) -> Option<(u64, &'a TypeInfo)> {
-    // split the a2l symbol name: e.g. "motortune.param._0_" -> ["motortune", "param", "_0_"]
-    let components = split_symbol_components(varname);
-
-    // find the symbol in the symbol table
-    find_symbol_from_components(&components, debug_data)
-}
-
-
-fn find_symbol_from_components<'a>(components: &Vec<&str>, debug_data: &'a DebugData) -> Option<(u64, &'a TypeInfo)> {
-    // the first component of the symbol name is the name of the global variable.
-    if let Some(varinfo) = debug_data.variables.get(components[0]) {
-        // we also need the type in order to resolve struct members, etc.
-        if let Some(vartype) = debug_data.types.get(&varinfo.typeref) {
-            // all further components of the symbol name are struct/union members or array indices
-            find_membertype(vartype, components, 1, varinfo.address)
-        } else {
-            // this exists for completeness, but shouldn't happen with a correctly generated elffile
-            // if the variable is present in the elffile, then the type should also be present
-            if components.len() == 1 {
-                Some((varinfo.address, &TypeInfo::Uint8))
-            } else {
-                None
-            }
-        }
-    } else {
-        None
-    }
-}
-
-
-// split the symbol into components
-// e.g. "my_struct.array_field[5][6]" -> [ "my_struct", "array_field", "[5]", "[6]" ]
-fn split_symbol_components(varname: &str) -> Vec<&str> {
-    let mut components: Vec<&str> = Vec::new();
-
-    for component in varname.split('.') {
-        if let Some(idx) = component.find('[') {
-            // "array_field[5][6]" -> "array_field", "[5][6]"
-            let (name, indexstring) = component.split_at(idx);
-            components.push(name);
-            components.extend(indexstring.split_inclusive(']'));
-        } else {
-            components.push(component);
-        }
-    }
-
-    components
-}
-
-
-// find the address and type of the current component of a symbol name
-fn find_membertype<'a>(
-    typeinfo: &'a TypeInfo,
-    components: &Vec<&str>,
-    component_index: usize,
-    address: u64
-) -> Option<(u64, &'a TypeInfo)> {
-    if component_index >= components.len() {
-        Some((address, typeinfo))
-    } else {
-        match typeinfo {
-            TypeInfo::Class { members, .. } |
-            TypeInfo::Struct { members, .. } |
-            TypeInfo::Union { members, .. } => {
-                if let Some((membertype, offset)) = members.get(components[component_index]) {
-                    find_membertype(
-                        membertype,
-                        components,
-                        component_index + 1,
-                        address + offset
-                    )
-                } else {
-                    None
-                }
-            }
-            TypeInfo::Array { dim, stride, arraytype, .. } => {
-                let mut multi_index = 0;
-                for idx_pos in 0 .. dim.len() {
-                    let arraycomponent = components.get(component_index + idx_pos)?;
-                    let indexval = get_index(arraycomponent)?;
-                    multi_index = multi_index * dim[idx_pos] as usize + indexval;
-                }
-
-                let elementaddr = address + (multi_index as u64 * stride);
-                find_membertype(
-                    arraytype,
-                    components,
-                    component_index + dim.len(),
-                    elementaddr
-                )
-            }
-            _ => Some((address, typeinfo))
-        }
-    }
-}
-
-
-// before ASAP2 1.7 array indices in symbol names could not written as [x], but only as _x_
-// this function will get the numerical index for either representation
-fn get_index(idxstr: &str) -> Option<usize> {
-    if (idxstr.starts_with('_') && idxstr.ends_with('_')) ||
-       (idxstr.starts_with('[') && idxstr.ends_with(']')) {
-        let idxstrlen = idxstr.len();
-        match idxstr[1..idxstrlen-1].parse() {
-            Ok(val) => Some(val),
-            Err(_) => None
-        }
-    } else {
-        None
-    }
-}
 
 
 // generate adjuste min and max limits based on the datatype.
@@ -369,90 +295,3 @@ impl UpdateSumary {
     }
 }
 
-#[test]
-fn test_split_symbol_components() {
-    let result = split_symbol_components("my_struct.array_field[5][1]");
-    assert_eq!(result.len(), 4);
-    assert_eq!(result[0], "my_struct");
-    assert_eq!(result[1], "array_field");
-    assert_eq!(result[2], "[5]");
-    assert_eq!(result[3], "[1]");
-
-    let result2 = split_symbol_components("my_struct.array_field._5_._1_");
-    assert_eq!(result2.len(), 4);
-    assert_eq!(result2[0], "my_struct");
-    assert_eq!(result2[1], "array_field");
-    assert_eq!(result2[2], "_5_");
-    assert_eq!(result2[3], "_1_");
-}
-
-#[test]
-fn test_find_symbol_of_array() {
-    let mut dbgdata = DebugData {
-        types: HashMap::new(),
-        variables: HashMap::new()
-    };
-    // global variable: uint32_t my_array[2]
-    dbgdata.variables.insert(
-        "my_array".to_string(),
-        crate::dwarf::VarInfo { address: 0x1234, typeref: 1 });
-    dbgdata.types.insert(
-        1,
-        TypeInfo::Array {
-            arraytype: Box::new(TypeInfo::Uint32),
-            dim: vec![2],
-            size: 8, // total size of the array
-            stride: 4
-        }
-    );
-
-    // try the different array indexing notations
-    let result1 = find_symbol("my_array._0_", &dbgdata);
-    assert!(result1.is_some());
-    // C-style notation is only allowed starting with ASAP2 version 1.7, before that the '[' and ']' are not allowed in names
-    let result3 = find_symbol("my_array[0]", &dbgdata);
-    assert!(result3.is_some());
-}
-
-
-#[test]
-fn test_find_symbol_of_array_in_struct() {
-    let mut dbgdata = DebugData {
-        types: HashMap::new(),
-        variables: HashMap::new()
-    };
-    // global variable defined in C like this:
-    // struct {
-    //        uint32_t array_item[2];
-    // } my_struct;
-    let mut structmembers: HashMap<String, (TypeInfo, u64)> = HashMap::new();
-    structmembers.insert(
-        "array_item".to_string(),
-        (
-            TypeInfo::Array {
-                arraytype: Box::new(TypeInfo::Uint32),
-                dim: vec![2],
-                size: 8,
-                stride: 4
-            },
-            0
-        )
-    );
-    dbgdata.variables.insert(
-        "my_struct".to_string(),
-        crate::dwarf::VarInfo { address: 0xcafe00, typeref: 2 });
-    dbgdata.types.insert(
-        2,
-        TypeInfo::Struct {
-            members: structmembers,
-            size: 4
-        }
-    );
-
-    // try the different array indexing notations
-    let result1 = find_symbol("my_struct.array_item._0_", &dbgdata);
-    assert!(result1.is_some());
-    // C-style notation is only allowed starting with ASAP2 version 1.7, before that the '[' and ']' are not allowed in names
-    let result3 = find_symbol("my_struct.array_item[0]", &dbgdata);
-    assert!(result3.is_some());
-}


### PR DESCRIPTION
Rather than silently failing to update an address, there can now be an error
mesage detailing what went wrong. These error messages are printed in verbose
mode only.
The error messages indicate problems like:
 - unknown symbols (variable is not present in the elf file)
 - unknown struct member within a known struct
 - array index out of bounds
 - etc.