### PR TITLE
implement handling of members inherited from base classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,18 +118,18 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.7"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
 dependencies = [
  "anstream",
  "anstyle",
@@ -176,9 +176,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -219,9 +219,9 @@ checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -229,15 +229,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "memchr"
@@ -324,9 +324,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags",
  "errno",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -433,7 +433,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/src/dwarf/attributes.rs
+++ b/src/dwarf/attributes.rs
@@ -5,8 +5,8 @@ type SliceType<'a> = EndianSlice<'a, RunTimeEndian>;
 type OptionalAttribute<'data> = Option<gimli::AttributeValue<SliceType<'data>>>;
 
 // try to get the attribute of the type attrtype for the DIE
-pub(crate) fn get_attr_value<'abbrev, 'unit>(
-    entry: &DebuggingInformationEntry<'abbrev, 'unit, SliceType, usize>,
+pub(crate) fn get_attr_value<'unit>(
+    entry: &DebuggingInformationEntry<'_, 'unit, SliceType, usize>,
     attrtype: gimli::DwAt,
 ) -> OptionalAttribute<'unit> {
     entry.attr_value(attrtype).unwrap_or(None)
@@ -186,14 +186,11 @@ pub(crate) fn get_bit_offset_attribute(
         } else {
             None
         }
-    } else if let Some(bit_offset_attr) = get_attr_value(entry, gimli::constants::DW_AT_bit_offset)
+    } else if let Some(gimli::AttributeValue::Udata(bit_offset)) =
+        get_attr_value(entry, gimli::constants::DW_AT_bit_offset)
     {
         // DW_AT_bit_offset: up to Dwarf 3
-        if let gimli::AttributeValue::Udata(bit_offset) = bit_offset_attr {
-            Some(bit_offset)
-        } else {
-            None
-        }
+        Some(bit_offset)
     } else {
         None
     }

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -31,7 +31,10 @@ pub(crate) fn insert_items(
         match insert_measurement(module, debugdata, measure_sym, &name_map, &sym_map) {
             Ok(measure_name) => {
                 log_msgs.push(format!("Inserted MEASUREMENT {}", measure_name));
-                name_map.insert(measure_name.to_owned(), ItemType::Measurement(module.measurement.len() - 1));
+                name_map.insert(
+                    measure_name.to_owned(),
+                    ItemType::Measurement(module.measurement.len() - 1),
+                );
                 measurement_list.push(measure_name);
             }
             Err(errmsg) => {
@@ -44,7 +47,10 @@ pub(crate) fn insert_items(
         match insert_characteristic(module, debugdata, characteristic_sym, &name_map, &sym_map) {
             Ok(characteristic_name) => {
                 log_msgs.push(format!("Inserted CHARACTERISTIC {}", characteristic_name));
-                name_map.insert(characteristic_name.to_owned(), ItemType::Characteristic(module.characteristic.len() - 1));
+                name_map.insert(
+                    characteristic_name.to_owned(),
+                    ItemType::Characteristic(module.characteristic.len() - 1),
+                );
                 characteristic_list.push(characteristic_name);
             }
             Err(errmsg) => {
@@ -68,9 +74,15 @@ fn insert_measurement(
 ) -> Result<String, String> {
     // get info about the symbol from the debug data
     match crate::symbol::find_symbol(measure_sym, debugdata) {
-        Ok((true_name, address, typeinfo)) => {
-            insert_measurement_sym(module, measure_sym, true_name, name_map, sym_map, typeinfo, address)
-        }
+        Ok((true_name, address, typeinfo)) => insert_measurement_sym(
+            module,
+            measure_sym,
+            true_name,
+            name_map,
+            sym_map,
+            typeinfo,
+            address,
+        ),
         Err(errmsg) => Err(format!(
             "Symbol {} could not be added: {}",
             measure_sym, errmsg
@@ -367,6 +379,7 @@ fn build_maps(module: &&mut Module) -> (HashMap<String, ItemType>, HashMap<Strin
     (name_map, sym_map)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn insert_many(
     a2l_file: &mut A2lFile,
     debugdata: &DebugData,

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,8 +176,7 @@ fn core() -> Result<(), String> {
         for mergemodule in merge_modules {
             let mut merge_log_msgs = Vec::<A2lError>::new();
             let mergeresult = a2lfile::load(mergemodule, None, &mut merge_log_msgs, strict);
-            if let Ok(mut merge_a2l) = mergeresult
-            {
+            if let Ok(mut merge_a2l) = mergeresult {
                 a2l_file.merge_modules(&mut merge_a2l);
                 cond_print!(
                     verbose,
@@ -200,7 +199,8 @@ fn core() -> Result<(), String> {
             } else {
                 return Err(format!(
                     "Failed to load \"{}\" for merging: {}\n",
-                    mergemodule.to_string_lossy(), mergeresult.unwrap_err().to_string()
+                    mergemodule.to_string_lossy(),
+                    mergeresult.unwrap_err()
                 ));
             }
         }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -120,7 +120,9 @@ fn get_symbol_info<'a>(
     // preferred: get symbol information from a SYMBOL_LINK attribute
     if let Some(symbol_link) = opt_symbol_link {
         match find_symbol(&symbol_link.symbol_name, debug_data) {
-            Ok((_, addr, typeinfo)) => return Ok((addr, typeinfo, symbol_link.symbol_name.clone())),
+            Ok((_, addr, typeinfo)) => {
+                return Ok((addr, typeinfo, symbol_link.symbol_name.clone()))
+            }
             Err(errmsg) => symbol_link_errmsg = Some(errmsg),
         };
     }


### PR DESCRIPTION
Handling of inherited members was missing completely. Therefore the addresses of inherited members could not be updated and they were removed by --cleanup