### PR TITLE
remove overriding the bitmask when not found in dwarf

### DIFF
--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -296,7 +296,11 @@ pub(crate) fn set_bitmask(opt_bitmask: &mut Option<BitMask>, typeinfo: &TypeInfo
             *opt_bitmask = Some(bm);
         }
     } else {
-        *opt_bitmask = None;
+        // if there was a bitmask already configured, it is probably an unexplicit bitfield (a bit
+        // mask is configured in the a2l, but in the code, it is an integer with hardcoded shift and
+        // mask), so we should not remove the bitmask from the a2l otherwise the configuration will
+        // be lost
+        //*opt_bitmask = None;
     }
 }
 


### PR DESCRIPTION
This happens when I want to update the characteristics addresses from the elf file.  If the symbol referenced by the characteristic is found not to be a bitfield then the bit_mask is removed from characteristic definition.

But in my case (and potentially all cases), when the symbol is not a bitfield, it is still an integer on which the characteristic itself it a bit field in that symbol.  In the code, the offset and masking operations are hardcoded on the integer but semantically there are several "characteristics" mapped to the same integer with different bit_masks.