### PR TITLE
Add handling for incomplete types in DWARF debug data

### DIFF
--- a/src/dwarf/attributes.rs
+++ b/src/dwarf/attributes.rs
@@ -421,3 +421,15 @@ pub(crate) fn get_type_attribute(
         _ => Err("failed to get DIE tree".to_string()),
     }
 }
+
+// get the DW_AT_declaration attribute
+pub(crate) fn get_declaration_attribute(
+    entry: &DebuggingInformationEntry<SliceType, usize>,
+) -> Option<bool> {
+    let decl_attr = get_attr_value(entry, gimli::constants::DW_AT_declaration)?;
+    if let gimli::AttributeValue::Flag(flag) = decl_attr {
+        Some(flag)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
C allows incomplete type declarations.
For example "struct foo;" only tells the compiler that his type exists, and results in a stub type entry with the attribute DW_AT_declaration in the DWARF data.
The DWARF typereader can now handle this case.

Fixes issue #38